### PR TITLE
To ignore "impl" folder in the .github/workflows/yaml-lint.yaml rules

### DIFF
--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -16,3 +16,5 @@ jobs:
             rules:
               line-length: disable
               document-start: disable
+            ignore: |
+              impl/


### PR DESCRIPTION
Fixes #28